### PR TITLE
Возможность изменения section у настроек

### DIFF
--- a/actions/SettingsAction.php
+++ b/actions/SettingsAction.php
@@ -85,7 +85,7 @@ class SettingsAction extends Action
     /**
      * @var array additional view params
      */
-    public $viewParams = array();
+    public $viewParams = [];
 
     /**
      * {@inheritdoc}
@@ -108,7 +108,7 @@ class SettingsAction extends Action
     {
         /* @var $model Model */
         $model = Yii::createObject($this->modelClass);
-        $event = Yii::createObject(array('class' => FormEvent::class, 'form' => $model));
+        $event = Yii::createObject(['class' => FormEvent::class, 'form' => $model]);
 
         if ($model->load(Yii::$app->request->post()) && $model->validate()) {
             $this->trigger(self::EVENT_BEFORE_SAVE, $event);
@@ -126,9 +126,9 @@ class SettingsAction extends Action
 
         $this->prepareModel($model);
 
-        return $this->controller->render($this->view, ArrayHelper::merge($this->viewParams, array(
+        return $this->controller->render($this->view, ArrayHelper::merge($this->viewParams, [
             'model' => $model,
-        )));
+        ]));
     }
 
     /**

--- a/actions/SettingsAction.php
+++ b/actions/SettingsAction.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace yii2mod\settings\actions;
 
 use Yii;
@@ -10,9 +20,7 @@ use yii\helpers\ArrayHelper;
 use yii2mod\settings\events\FormEvent;
 
 /**
- * Class SettingsAction
- *
- * @package yii2mod\settings\actions
+ * Class SettingsAction.
  */
 class SettingsAction extends Action
 {
@@ -35,8 +43,8 @@ class SettingsAction extends Action
 
     /**
      * @var callable a PHP callable that will be called for save the settings.
-     * If not set, [[saveSettings()]] will be used instead.
-     * The signature of the callable should be:
+     *               If not set, [[saveSettings()]] will be used instead.
+     *               The signature of the callable should be:
      *
      * ```php
      * function ($model) {
@@ -48,8 +56,8 @@ class SettingsAction extends Action
 
     /**
      * @var callable a PHP callable that will be called to prepare a model.
-     * If not set, [[prepareModel()]] will be used instead.
-     * The signature of the callable should be:
+     *               If not set, [[prepareModel()]] will be used instead.
+     *               The signature of the callable should be:
      *
      * ```php
      * function ($model) {
@@ -77,10 +85,10 @@ class SettingsAction extends Action
     /**
      * @var array additional view params
      */
-    public $viewParams = [];
+    public $viewParams = array();
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function init()
     {
@@ -100,7 +108,7 @@ class SettingsAction extends Action
     {
         /* @var $model Model */
         $model = Yii::createObject($this->modelClass);
-        $event = Yii::createObject(['class' => FormEvent::class, 'form' => $model]);
+        $event = Yii::createObject(array('class' => FormEvent::class, 'form' => $model));
 
         if ($model->load(Yii::$app->request->post()) && $model->validate()) {
             $this->trigger(self::EVENT_BEFORE_SAVE, $event);
@@ -118,13 +126,13 @@ class SettingsAction extends Action
 
         $this->prepareModel($model);
 
-        return $this->controller->render($this->view, ArrayHelper::merge($this->viewParams, [
+        return $this->controller->render($this->view, ArrayHelper::merge($this->viewParams, array(
             'model' => $model,
-        ]));
+        )));
     }
 
     /**
-     * Prepares the model which will be used to validate the attributes
+     * Prepares the model which will be used to validate the attributes.
      *
      * @param Model $model
      */
@@ -155,13 +163,15 @@ class SettingsAction extends Action
 
     /**
      * @param Model $model
+     *
      * @return string
      */
     protected function getSection(Model $model)
     {
-        if($this->sectionSettings) {
+        if ($this->sectionSettings) {
             return $this->sectionSettings;
         }
+
         return $model->formName();
     }
 }

--- a/actions/SettingsAction.php
+++ b/actions/SettingsAction.php
@@ -60,6 +60,11 @@ class SettingsAction extends Action
     public $prepareModel;
 
     /**
+     * @var string
+     */
+    public $sectionSettings;
+
+    /**
      * @var string message to be set on successful save a model
      */
     public $successMessage = 'Settings have been saved successfully.';
@@ -129,7 +134,7 @@ class SettingsAction extends Action
             call_user_func($this->prepareModel, $model);
         } else {
             foreach ($model->attributes() as $attribute) {
-                $model->{$attribute} = Yii::$app->settings->get($model->formName(), $attribute);
+                $model->{$attribute} = Yii::$app->settings->get($model->getSection($model), $attribute);
             }
         }
     }
@@ -143,8 +148,20 @@ class SettingsAction extends Action
             call_user_func($this->saveSettings, $model);
         } else {
             foreach ($model->toArray() as $key => $value) {
-                Yii::$app->settings->set($model->formName(), $key, $value);
+                Yii::$app->settings->set($model->getSection($model), $key, $value);
             }
         }
+    }
+
+    /**
+     * @param Model $model
+     * @return string
+     */
+    protected function getSection(Model $model)
+    {
+        if($this->sectionSettings) {
+            return $this->sectionSettings;
+        }
+        return $model->formName();
     }
 }

--- a/actions/SettingsAction.php
+++ b/actions/SettingsAction.php
@@ -134,7 +134,7 @@ class SettingsAction extends Action
             call_user_func($this->prepareModel, $model);
         } else {
             foreach ($model->attributes() as $attribute) {
-                $model->{$attribute} = Yii::$app->settings->get($model->getSection($model), $attribute);
+                $model->{$attribute} = Yii::$app->settings->get($this->getSection($model), $attribute);
             }
         }
     }
@@ -148,7 +148,7 @@ class SettingsAction extends Action
             call_user_func($this->saveSettings, $model);
         } else {
             foreach ($model->toArray() as $key => $value) {
-                Yii::$app->settings->set($model->getSection($model), $key, $value);
+                Yii::$app->settings->set($this->getSection($model), $key, $value);
             }
         }
     }


### PR DESCRIPTION
Добрый день @igor-chepurnoi 

Очень хорошо что вы добавили методы prepareModel и saveSettings. Они могу пригодиться, но я хотел всего лишь иметь возможность изменить поле section у настройки.

Для чего это нужно:
В моем проекте планируется достаточно большое количество модулей. Для каждого потребуется своя страница с настройками. Соответственно у каждого модуля будет своя модель ConfigurationForm. Переопределять метод formName, как вы советовали, желания нет, потому что будет получаться следующая несуразица при рендеринге формы [http://joxi.ru/v29dqbds3Xk0ym](http://joxi.ru/v29dqbds3Xk0ym)

А с помощью поля sectionSettings будет возможность изменить поле section в бд по желанию. Да, это можно было бы сделать и с новыми методами prepareModel и saveSettings, но это будет куча дублирующего кода по всему проекту.
