### PR TITLE
Не записывать null значение в аттрибут модели

### DIFF
--- a/actions/SettingsAction.php
+++ b/actions/SettingsAction.php
@@ -142,7 +142,10 @@ class SettingsAction extends Action
             call_user_func($this->prepareModel, $model);
         } else {
             foreach ($model->attributes() as $attribute) {
-                $model->{$attribute} = Yii::$app->settings->get($this->getSection($model), $attribute);
+                $value = Yii::$app->settings->get($this->getSection($model), $attribute);
+                if (!is_null($value)) {
+                    $model->{$attribute} = $value;
+                }
             }
         }
     }


### PR DESCRIPTION
Добрый день Игорь!

Я хотел бы указывать на странице с формой значение по умолчанию у полей, но я не могу это сделать из-за того, что любое значение перезаписывается.

```
class ConfigurationForm extends Model
{
    public $field = 0;
}
```

Я пользуюсь третьим входным параметром в методе `Yii::$app->settings->get('section', 'key', 0);`
Но было бы удобно иметь возможность отображать значение по умолчанию и в форме настроек.